### PR TITLE
Replace esclave with agent in stride-notif plugin (fr)

### DIFF
--- a/target/jenkins-for-test/help/project-config/custom-workspace_fr.html
+++ b/target/jenkins-for-test/help/project-config/custom-workspace_fr.html
@@ -21,7 +21,7 @@
 
   <p>
   Si vous êtes dans un environnement distribué, à moins d'associer un job à un noeud (une machine) spécifique,
-  Jenkins sera toujours capable de déporter des jobs sur différentes machines esclaves, même si cette option
+  Jenkins sera toujours capable de déporter des jobs sur différentes machines agents, même si cette option
   est utilisée. Parfois, cela est souhaitable; parfois, non.<br>
   Par ailleurs, il est possible d'associer plusieurs projets à un même répertoire de travail;
   assurez-vous dans ce cas que des exécutions concurrentes de ces jobs n'interfèrent pas de façon

--- a/target/jenkins-for-test/help/system-config/master-slave/availability_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/availability_fr.html
@@ -1,39 +1,39 @@
 <div>
-    Contrôle le moment où Jenkins démarrage et arrête l'esclave.
+    Contrôle le moment où Jenkins démarrage et arrête l'agent.
 
     <dl>
         <dt><b>
-            Maintenir l'esclave activé le plus longtemps possible
+            Maintenir l'agent activé le plus longtemps possible
         </b></dt>
         <dd>
             C'est la configuration par défaut et la plus classique.
-            Dans ce mode, Jenkins fait des tests réguliers pour conserver l'esclave
+            Dans ce mode, Jenkins fait des tests réguliers pour conserver l'agent
             actif.
-            Si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur et
-            que l'esclave n'est pas disponible,
+            Si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur et
+            que l'agent n'est pas disponible,
             il tentera régulièrement de le relancer.
             Jenkins ne cherchera pas à le désactiver.
         </dd>
 
         <!--dt><b>
-            Arrêter et démarrer l'esclave à des moment spécifiques
+            Arrêter et démarrer l'agent à des moment spécifiques
         </b></dt>
         <dd>
-            Dans ce mode, Jenkins conservera l'esclave activé selon les horaires configurés.
-            Si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur et
-            que l'esclave n'est pas disponible dans la fenêtre où cet
+            Dans ce mode, Jenkins conservera l'agent activé selon les horaires configurés.
+            Si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur et
+            que l'agent n'est pas disponible dans la fenêtre où cet
             il est censé être activé,
             il tentera régulièrement de le relancer.
 
-            Pendant la fenêtre où l'esclave est censé être désactivé, il ne le sera
+            Pendant la fenêtre où l'agent est censé être désactivé, il ne le sera
             réellement que s'il n'a pas de job en cours.
         </dd-->
 
         <dt><b>
-            Activer l'esclave en cas nécessité et le désactiver lorsqu'il n'est plus nécessaire
+            Activer l'agent en cas nécessité et le désactiver lorsqu'il n'est plus nécessaire
         </b></dt>
         <dd>
-            Dans ce mode, si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur, il
+            Dans ce mode, si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur, il
             cherchera régulièrement à l'activer tant qu'il y aura des jobs en attente
             respectant les critères suivants&nbsp;:
             <ul>
@@ -43,8 +43,8 @@
 
             L'esclace sera désactivé si&nbsp;:
             <ul>
-                <li>Il n'y a plus de job en cours sur cet esclave</li>
-                <li>L'esclave a été inactif depuis au moins la période d'inactivité spécifiée</li>
+                <li>Il n'y a plus de job en cours sur cet agent</li>
+                <li>L'agent a été inactif depuis au moins la période d'inactivité spécifiée</li>
             </ul>
         </dd>
     </dl>

--- a/target/jenkins-for-test/help/system-config/master-slave/clock_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/clock_fr.html
@@ -1,6 +1,6 @@
 ﻿<div>
   De nombreux aspects d'un build dépendent de l'horloge. Par conséquent, si
-  l'horloge de la machine qui exécute Jenkins et celle de la machine esclave
+  l'horloge de la machine qui exécute Jenkins et celle de la machine agent
   sont très différentes, des comportements étranges peuvent se voir.
   Il est recommandé d'utiliser NTP pour synchroniser les horloges entre
   les machines.

--- a/target/jenkins-for-test/help/system-config/master-slave/demand/idleDelay_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/demand/idleDelay_fr.html
@@ -1,3 +1,3 @@
 <div>
-    Le nombre de minutes d'inactivité de cet esclave avant la tentative de déconnexion.
+    Le nombre de minutes d'inactivité de cet agent avant la tentative de déconnexion.
 </div>

--- a/target/jenkins-for-test/help/system-config/master-slave/demand/inDemandDelay_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/demand/inDemandDelay_fr.html
@@ -1,4 +1,4 @@
 <div>
     Le nombre de minutes que les jobs doivent attendre dans la file d'attente, avant
-    la tentative d'activation de cet esclave.
+    la tentative d'activation de cet agent.
 </div>

--- a/target/jenkins-for-test/help/system-config/master-slave/description_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/description_fr.html
@@ -1,11 +1,11 @@
 ﻿<div>
-  Une description optionnelle de cet esclave, lisible pour un être humain.
+  Une description optionnelle de cet agent, lisible pour un être humain.
   Cette information est affichée sur l'écran de configuration du projet.
 
   <p>
-  Quand vous avez des esclaves différents des autres, il est souvent
+  Quand vous avez des agents différents des autres, il est souvent
   utile d'utiliser ce champ pour expliquer ces différences. Par exemple,
-  "Esclave Windows" permet aux propriétaires des projets de choisir de
+  "Agent Windows" permet aux propriétaires des projets de choisir de
   toujours construire sur une machine Windows (typiquement, s'ils ont besoin
   d'un outil spécifique sous Windows).
 </div>

--- a/target/jenkins-for-test/help/system-config/master-slave/jnlp-tunnel_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/jnlp-tunnel_fr.html
@@ -1,5 +1,5 @@
 <div>
-    Quand un esclave est lancé par JNLP, l'agent de l'esclave tente de se connecter à Jenkins par un port
+    Quand un agent est lancé par JNLP, l'agent de l'agent tente de se connecter à Jenkins par un port
     TCP spécifique, afin d'établir un canal de communication.
     Certains réseaux très sécurisés peuvent vous empècher d'effectuer cette connexion.
     Cela peut également être le cas quand Jenkins tourne derrière un répartiteur de charge (load balancer),
@@ -9,9 +9,9 @@
     <p>
     Cette option de tunneling vous permet, dans ces situations, de rediriger la connexion sur un autre host ou
     un autre numéro de port. Le champ supporte les formats "<tt>HOST:PORT</tt>", "<tt>:PORT</tt>" et "<tt>HOST:</tt>".
-    Dans le premier format, l'agent JNLP de l'esclave se connectera sur le numéro de port TCP et le host spécifiés et
+    Dans le premier format, l'agent JNLP de l'agent se connectera sur le numéro de port TCP et le host spécifiés et
     supposera que vous avez configuré votre réseau de façon à ce que ce port fasse suivre la connexion sur le
-    port TCP de l'esclave JNLP de Jenkins.
+    port TCP de l'agent JNLP de Jenkins.
 
     <p>
     Dans les deux derniers formats, le nom de host et le numéro de port par défaut (c'est-à-dire le nom de host que

--- a/target/jenkins-for-test/help/system-config/master-slave/jnlpSecurity_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/jnlpSecurity_fr.html
@@ -33,12 +33,12 @@
         <dd>
             Dans ce mode, Jenkins fournit le lien de lancement JNLP
             sur la vue de l'ordinateur. Le lien sera toujours disponible
-            quand la machine-esclave est déconnectée.
+            quand la machine-agent est déconnectée.
             <br />
             <b>Attention!</b> Dans ce modèle, la sécurité est désactivée.
-            Les esclaves peuvent donc être lancés par
+            Les agents peuvent donc être lancés par
             <em>toutes les personnes qui ont accès au serveur</em>. 
-            Les esclaves ont la capacité d'exécuter n'importe quel code
+            Les agents ont la capacité d'exécuter n'importe quel code
             sur la machine maître.
             <b>Ne sélectionnez pas cette option si vous n'avez pas
             bien conscience des risques encourus.</b>

--- a/target/jenkins-for-test/help/system-config/master-slave/numExecutors_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/numExecutors_fr.html
@@ -1,6 +1,6 @@
 ﻿<div>
   Ceci contrôle le nombre de builds concurrents que Jenkins peut exécuter
-  sur cet esclave. La valeur affecte la charge système que Jenkins peut
+  sur cet agent. La valeur affecte la charge système que Jenkins peut
   causer. Une bonne valeur pour commencer serait le nombre de processeurs.
 
   <p>
@@ -10,6 +10,6 @@
   pendant qu'un autre est en attente d'entrées/sorties.
 
   <p>
-  Positionner cette valeur à 0 est utile pour désactiver un esclave
+  Positionner cette valeur à 0 est utile pour désactiver un agent
   temporairement indisponible, sans perdre le reste de la configuration.
 </div>

--- a/target/jenkins-for-test/help/system-config/master-slave/usage_fr.html
+++ b/target/jenkins-for-test/help/system-config/master-slave/usage_fr.html
@@ -3,12 +3,12 @@
 
   <dl>
     <dt><b>
-      Utilise cet esclave le plus possible
+      Utilise cet agent le plus possible
     </b></dt>
     <dd>
       C'est l'option normale, configurée par défaut.
-      Dans ce mode, Jenkins utilise librement cet esclave. A chaque fois
-      qu'un build peut être exécuté sur cet esclave, Jenkins le fera.
+      Dans ce mode, Jenkins utilise librement cet agent. A chaque fois
+      qu'un build peut être exécuté sur cet agent, Jenkins le fera.
     </dd>
 
     <dt><b>
@@ -16,14 +16,14 @@
     </b></dt>
     <dd>
       Dans ce mode, Jenkinsne construira un projet sur cette machine que
-      lorsque un projet aura été assigné spécifiquement à cet esclave. 
+      lorsque un projet aura été assigné spécifiquement à cet agent. 
       
-      Cela permet à un esclave de n'être utilisé que pour certains types
+      Cela permet à un agent de n'être utilisé que pour certains types
       de jobs. Par exemple, pour lancer des tests de performance en
       continu à partir de Jenkins, vous pouvez utiliser cette option
       avec le nombre d'exécuteurs à 1, afin de ne lancer qu'un test de
       performance à la fois. Cet exécuteur ne sera pas bloqué par les
-      autres builds qui peuvent être lancés sur les autres esclaves.
+      autres builds qui peuvent être lancés sur les autres agents.
     </dd>
   </dl>
 </div>

--- a/target/tmp/webapp/help/project-config/custom-workspace_fr.html
+++ b/target/tmp/webapp/help/project-config/custom-workspace_fr.html
@@ -21,7 +21,7 @@
 
   <p>
   Si vous êtes dans un environnement distribué, à moins d'associer un job à un noeud (une machine) spécifique,
-  Jenkins sera toujours capable de déporter des jobs sur différentes machines esclaves, même si cette option
+  Jenkins sera toujours capable de déporter des jobs sur différentes machines agents, même si cette option
   est utilisée. Parfois, cela est souhaitable; parfois, non.<br>
   Par ailleurs, il est possible d'associer plusieurs projets à un même répertoire de travail;
   assurez-vous dans ce cas que des exécutions concurrentes de ces jobs n'interfèrent pas de façon

--- a/target/tmp/webapp/help/system-config/master-slave/availability_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/availability_fr.html
@@ -1,39 +1,39 @@
 <div>
-    Contrôle le moment où Jenkins démarrage et arrête l'esclave.
+    Contrôle le moment où Jenkins démarrage et arrête l'agent.
 
     <dl>
         <dt><b>
-            Maintenir l'esclave activé le plus longtemps possible
+            Maintenir l'agent activé le plus longtemps possible
         </b></dt>
         <dd>
             C'est la configuration par défaut et la plus classique.
-            Dans ce mode, Jenkins fait des tests réguliers pour conserver l'esclave
+            Dans ce mode, Jenkins fait des tests réguliers pour conserver l'agent
             actif.
-            Si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur et
-            que l'esclave n'est pas disponible,
+            Si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur et
+            que l'agent n'est pas disponible,
             il tentera régulièrement de le relancer.
             Jenkins ne cherchera pas à le désactiver.
         </dd>
 
         <!--dt><b>
-            Arrêter et démarrer l'esclave à des moment spécifiques
+            Arrêter et démarrer l'agent à des moment spécifiques
         </b></dt>
         <dd>
-            Dans ce mode, Jenkins conservera l'esclave activé selon les horaires configurés.
-            Si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur et
-            que l'esclave n'est pas disponible dans la fenêtre où cet
+            Dans ce mode, Jenkins conservera l'agent activé selon les horaires configurés.
+            Si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur et
+            que l'agent n'est pas disponible dans la fenêtre où cet
             il est censé être activé,
             il tentera régulièrement de le relancer.
 
-            Pendant la fenêtre où l'esclave est censé être désactivé, il ne le sera
+            Pendant la fenêtre où l'agent est censé être désactivé, il ne le sera
             réellement que s'il n'a pas de job en cours.
         </dd-->
 
         <dt><b>
-            Activer l'esclave en cas nécessité et le désactiver lorsqu'il n'est plus nécessaire
+            Activer l'agent en cas nécessité et le désactiver lorsqu'il n'est plus nécessaire
         </b></dt>
         <dd>
-            Dans ce mode, si Jenkins peut démarrer l'esclave sans l'aide de l'utilisateur, il
+            Dans ce mode, si Jenkins peut démarrer l'agent sans l'aide de l'utilisateur, il
             cherchera régulièrement à l'activer tant qu'il y aura des jobs en attente
             respectant les critères suivants&nbsp;:
             <ul>
@@ -43,8 +43,8 @@
 
             L'esclace sera désactivé si&nbsp;:
             <ul>
-                <li>Il n'y a plus de job en cours sur cet esclave</li>
-                <li>L'esclave a été inactif depuis au moins la période d'inactivité spécifiée</li>
+                <li>Il n'y a plus de job en cours sur cet agent</li>
+                <li>L'agent a été inactif depuis au moins la période d'inactivité spécifiée</li>
             </ul>
         </dd>
     </dl>

--- a/target/tmp/webapp/help/system-config/master-slave/clock_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/clock_fr.html
@@ -1,6 +1,6 @@
 ﻿<div>
   De nombreux aspects d'un build dépendent de l'horloge. Par conséquent, si
-  l'horloge de la machine qui exécute Jenkins et celle de la machine esclave
+  l'horloge de la machine qui exécute Jenkins et celle de la machine agent
   sont très différentes, des comportements étranges peuvent se voir.
   Il est recommandé d'utiliser NTP pour synchroniser les horloges entre
   les machines.

--- a/target/tmp/webapp/help/system-config/master-slave/demand/idleDelay_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/demand/idleDelay_fr.html
@@ -1,3 +1,3 @@
 <div>
-    Le nombre de minutes d'inactivité de cet esclave avant la tentative de déconnexion.
+    Le nombre de minutes d'inactivité de cet agent avant la tentative de déconnexion.
 </div>

--- a/target/tmp/webapp/help/system-config/master-slave/demand/inDemandDelay_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/demand/inDemandDelay_fr.html
@@ -1,4 +1,4 @@
 <div>
     Le nombre de minutes que les jobs doivent attendre dans la file d'attente, avant
-    la tentative d'activation de cet esclave.
+    la tentative d'activation de cet agent.
 </div>

--- a/target/tmp/webapp/help/system-config/master-slave/description_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/description_fr.html
@@ -1,11 +1,11 @@
 ﻿<div>
-  Une description optionnelle de cet esclave, lisible pour un être humain.
+  Une description optionnelle de cet agent, lisible pour un être humain.
   Cette information est affichée sur l'écran de configuration du projet.
 
   <p>
-  Quand vous avez des esclaves différents des autres, il est souvent
+  Quand vous avez des agents différents des autres, il est souvent
   utile d'utiliser ce champ pour expliquer ces différences. Par exemple,
-  "Esclave Windows" permet aux propriétaires des projets de choisir de
+  "Agent Windows" permet aux propriétaires des projets de choisir de
   toujours construire sur une machine Windows (typiquement, s'ils ont besoin
   d'un outil spécifique sous Windows).
 </div>

--- a/target/tmp/webapp/help/system-config/master-slave/jnlp-tunnel_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/jnlp-tunnel_fr.html
@@ -1,5 +1,5 @@
 <div>
-    Quand un esclave est lancé par JNLP, l'agent de l'esclave tente de se connecter à Jenkins par un port
+    Quand un agent est lancé par JNLP, l'agent de l'agent tente de se connecter à Jenkins par un port
     TCP spécifique, afin d'établir un canal de communication.
     Certains réseaux très sécurisés peuvent vous empècher d'effectuer cette connexion.
     Cela peut également être le cas quand Jenkins tourne derrière un répartiteur de charge (load balancer),
@@ -9,9 +9,9 @@
     <p>
     Cette option de tunneling vous permet, dans ces situations, de rediriger la connexion sur un autre host ou
     un autre numéro de port. Le champ supporte les formats "<tt>HOST:PORT</tt>", "<tt>:PORT</tt>" et "<tt>HOST:</tt>".
-    Dans le premier format, l'agent JNLP de l'esclave se connectera sur le numéro de port TCP et le host spécifiés et
+    Dans le premier format, l'agent JNLP de l'agent se connectera sur le numéro de port TCP et le host spécifiés et
     supposera que vous avez configuré votre réseau de façon à ce que ce port fasse suivre la connexion sur le
-    port TCP de l'esclave JNLP de Jenkins.
+    port TCP de l'agent JNLP de Jenkins.
 
     <p>
     Dans les deux derniers formats, le nom de host et le numéro de port par défaut (c'est-à-dire le nom de host que

--- a/target/tmp/webapp/help/system-config/master-slave/jnlpSecurity_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/jnlpSecurity_fr.html
@@ -33,12 +33,12 @@
         <dd>
             Dans ce mode, Jenkins fournit le lien de lancement JNLP
             sur la vue de l'ordinateur. Le lien sera toujours disponible
-            quand la machine-esclave est déconnectée.
+            quand la machine-agent est déconnectée.
             <br />
             <b>Attention!</b> Dans ce modèle, la sécurité est désactivée.
-            Les esclaves peuvent donc être lancés par
+            Les agents peuvent donc être lancés par
             <em>toutes les personnes qui ont accès au serveur</em>. 
-            Les esclaves ont la capacité d'exécuter n'importe quel code
+            Les agents ont la capacité d'exécuter n'importe quel code
             sur la machine maître.
             <b>Ne sélectionnez pas cette option si vous n'avez pas
             bien conscience des risques encourus.</b>

--- a/target/tmp/webapp/help/system-config/master-slave/numExecutors_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/numExecutors_fr.html
@@ -1,6 +1,6 @@
 ﻿<div>
   Ceci contrôle le nombre de builds concurrents que Jenkins peut exécuter
-  sur cet esclave. La valeur affecte la charge système que Jenkins peut
+  sur cet agent. La valeur affecte la charge système que Jenkins peut
   causer. Une bonne valeur pour commencer serait le nombre de processeurs.
 
   <p>
@@ -10,6 +10,6 @@
   pendant qu'un autre est en attente d'entrées/sorties.
 
   <p>
-  Positionner cette valeur à 0 est utile pour désactiver un esclave
+  Positionner cette valeur à 0 est utile pour désactiver un agent
   temporairement indisponible, sans perdre le reste de la configuration.
 </div>

--- a/target/tmp/webapp/help/system-config/master-slave/usage_fr.html
+++ b/target/tmp/webapp/help/system-config/master-slave/usage_fr.html
@@ -3,12 +3,12 @@
 
   <dl>
     <dt><b>
-      Utilise cet esclave le plus possible
+      Utilise cet agent le plus possible
     </b></dt>
     <dd>
       C'est l'option normale, configurée par défaut.
-      Dans ce mode, Jenkins utilise librement cet esclave. A chaque fois
-      qu'un build peut être exécuté sur cet esclave, Jenkins le fera.
+      Dans ce mode, Jenkins utilise librement cet agent. A chaque fois
+      qu'un build peut être exécuté sur cet agent, Jenkins le fera.
     </dd>
 
     <dt><b>
@@ -16,14 +16,14 @@
     </b></dt>
     <dd>
       Dans ce mode, Jenkinsne construira un projet sur cette machine que
-      lorsque un projet aura été assigné spécifiquement à cet esclave. 
+      lorsque un projet aura été assigné spécifiquement à cet agent. 
       
-      Cela permet à un esclave de n'être utilisé que pour certains types
+      Cela permet à un agent de n'être utilisé que pour certains types
       de jobs. Par exemple, pour lancer des tests de performance en
       continu à partir de Jenkins, vous pouvez utiliser cette option
       avec le nombre d'exécuteurs à 1, afin de ne lancer qu'un test de
       performance à la fois. Cet exécuteur ne sera pas bloqué par les
-      autres builds qui peuvent être lancés sur les autres esclaves.
+      autres builds qui peuvent être lancés sur les autres agents.
     </dd>
   </dl>
 </div>


### PR DESCRIPTION
The word esclave(s) appeared in the French documentation for the maven plugin; I changed it to agent(s) (consistent with previous PRs).